### PR TITLE
feat: add SiweService plugin for Sign In With Ethereum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ First, configure your Better Auth client in your application:
 import { ApplicationConfig } from '@angular/core'
 import { provideBetterAuth } from 'ngx-better-auth'
 import { environment } from './environments/environment'
-import { adminClient, twoFactorClient, usernameClient } from 'better-auth/client/plugins'
+import { adminClient, siweClient, twoFactorClient, usernameClient } from 'better-auth/client/plugins'
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -60,6 +60,7 @@ export const appConfig: ApplicationConfig = {
             user,
           },
         }),
+        siweClient(),
       ],
     })
   ]
@@ -84,7 +85,7 @@ The full list of methods  is available at the end of this README.
 - ✅ Passkey ➡️ `PasskeyService`
 - ✅ Generic OAuth ➡️ `GenericOauthService`
 - ✅ One Tap ➡️ `OneTapService`
-- ❌ Sign In With Ethereum
+- ✅ Sign In With Ethereum (SIWE) ➡️ `SiweService`
 
 ### Authorization
 - ✅ Admin ➡️ `AdminService`

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -12,3 +12,5 @@ export * from './plugins/username.service'
 
 export * from './plugins/admin.service'
 export * from './plugins/organization.service'
+
+export * from './plugins/siwe.service'

--- a/src/lib/services/plugins/siwe.service.ts
+++ b/src/lib/services/plugins/siwe.service.ts
@@ -1,0 +1,66 @@
+import { inject, Injectable } from '@angular/core'
+import { defer, filter, map, Observable, switchMap } from 'rxjs'
+import { validatePlugin } from '../../utils/validate-plugin'
+import { MainService } from '../main.service'
+import { AuthService } from '../auth.service'
+
+export interface SiweNonceResult {
+  nonce: string
+}
+
+export interface SiweVerifyResult {
+  token: string
+  success: boolean
+  user: {
+    id: string
+    walletAddress: string
+    chainId: number
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+export class SiweService {
+  private readonly mainService = inject(MainService)
+  private readonly authService = inject(AuthService)
+
+  siwe: any
+
+  constructor() {
+    const client = this.mainService.authClient as { siwe?: any }
+    validatePlugin(client, 'siwe')
+    this.siwe = client.siwe
+  }
+
+  /**
+   * Fetches a nonce for the given wallet address to be included in the SIWE message.
+   * @param data - The wallet address and optional chain ID
+   */
+  getNonce(data: { walletAddress: string; chainId?: number }): Observable<SiweNonceResult> {
+    return defer(() => this.siwe.getSiweNonce(data)).pipe(
+      map((res) => this.mainService.mapData<SiweNonceResult>(res as any)),
+    )
+  }
+
+  /**
+   * Verifies a signed SIWE message and signs the user in.
+   * On success, waits for the session to be established before emitting.
+   * @param data - The signed message, signature, wallet address, optional chain ID and optional email
+   */
+  verifyMessage(data: {
+    message: string
+    signature: string
+    walletAddress: string
+    chainId?: number
+    email?: string
+  }): Observable<SiweVerifyResult> {
+    return defer(() => this.siwe.verifySiweMessage(data)).pipe(
+      map((res) => this.mainService.mapData<SiweVerifyResult>(res as any)),
+      switchMap((result) =>
+        this.authService.sessionState$.pipe(
+          filter((s) => s !== null),
+          map(() => result),
+        ),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
Adds client-side Angular service support for the better-auth SIWE plugin.

- New `SiweService` with `getNonce()` and `verifyMessage()` methods
- Follows existing plugin service patterns (defer, mapData, validatePlugin)
- Exported from the main services barrel
- README updated: plugin listed as supported, setup example updated
